### PR TITLE
Remove SONAR_TOKEN secret from Internal and Public workflows

### DIFF
--- a/.github/workflows/Internal.yml
+++ b/.github/workflows/Internal.yml
@@ -14,5 +14,4 @@ jobs:
     with:
       sonarcloud-project-name: ${{ vars.SONAR_NAME }}
     secrets:
-      # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       NUGET_API_KEY: ${{ secrets.NUGETAPIKEY_GITHUB  }}

--- a/.github/workflows/Public.yml
+++ b/.github/workflows/Public.yml
@@ -12,5 +12,4 @@ jobs:
       sonarcloud-project-name: ${{ vars.SONAR_NAME }}
       nuget-push-source: "https://api.nuget.org/v3/index.json"
     secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       NUGET_API_KEY: ${{ secrets.NUGETAPIKEY }}


### PR DESCRIPTION
This pull request updates secret handling in GitHub Actions workflow files, specifically adjusting how SonarCloud authentication is configured.

**CI/CD workflow updates:**

* [`.github/workflows/Public.yml`](diffhunk://#diff-059f4c35429e3d89aa35c7ed319e92aa4cbc7db1de886744b55b3d99a786cce9L15): Removed the `SONAR_TOKEN` secret from the public workflow, which disables SonarCloud integration for public builds.
* [`.github/workflows/Internal.yml`](diffhunk://#diff-2695e96a36980a8ecda99820bed63e291faa0e1d2fffef63cdf5cb723811353fL17): Removed a commented-out `SONAR_TOKEN` secret, cleaning up the internal workflow configuration.